### PR TITLE
Fix two buffer overflows

### DIFF
--- a/ta/bip32.c
+++ b/ta/bip32.c
@@ -139,7 +139,7 @@ TEE_Result hdnode_private_ckd(uint8_t* parent_sk, uint8_t* parent_chaincode, uin
 TEE_Result hdnode_public_ckd(uint8_t* parent_sk, uint8_t* parent_chaincode, uint32_t i, uint8_t* child_pk_x, uint8_t* child_pk_y)
 {
 	uint8_t child_sk[32];
-	uint8_t child_pk[32];
+	uint8_t child_pk[65];
 	uint8_t child_chaincode[32];
 	const ecdsa_curve* curve = &secp256k1;
 

--- a/ta/bitcoin_wallet_ta.c
+++ b/ta/bitcoin_wallet_ta.c
@@ -228,7 +228,7 @@ static TEE_Result get_bitcoin_address(uint32_t param_types, TEE_Param params[4])
 												TEE_PARAM_TYPE_MEMREF_OUTPUT, 
 												TEE_PARAM_TYPE_NONE);
 	uint32_t account_id;
-	uint8_t address[25];
+	uint8_t address[34];
 	TEE_Result res;
 	
 	DMSG("has been called");


### PR DESCRIPTION
There were two buffer overflow bugs in the TA "get_bitcoin_address" code path.
One regarding the buffer holding the public key, and another in a buffer regarding the address in encoded as base58